### PR TITLE
Fix up exposed interface

### DIFF
--- a/patrol.cabal
+++ b/patrol.cabal
@@ -134,6 +134,7 @@ test-suite patrol-test-suite
     bytestring,
     case-insensitive,
     containers,
+    exceptions,
     hspec ^>=2.11.8,
     http-client,
     http-types,

--- a/source/library/Patrol/Type/Dsn.hs
+++ b/source/library/Patrol/Type/Dsn.hs
@@ -24,7 +24,7 @@ data Dsn = Dsn
   deriving (Eq, Show)
 
 fromText :: (Catch.MonadThrow m) => Text.Text -> m Dsn
-fromText text = case Uri.parseURI (Text.unpack text) of
+fromText text = case Uri.parseURI $ Text.unpack text of
   Nothing -> Catch.throwM $ Problem.Problem "invalid URI"
   Just uri -> fromUri uri
 

--- a/source/library/Patrol/Type/Exception.hs
+++ b/source/library/Patrol/Type/Exception.hs
@@ -4,7 +4,6 @@ import qualified Control.Monad.Catch as Catch
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as Text
 import qualified Data.Typeable as Typeable
-import qualified GHC.Stack as Stack
 import qualified Patrol.Extra.Aeson as Aeson
 import qualified Patrol.Type.Mechanism as Mechanism
 import qualified Patrol.Type.Stacktrace as Stacktrace
@@ -42,14 +41,9 @@ empty =
       value = Text.empty
     }
 
-fromException ::
-  (Catch.Exception e) =>
-  (Catch.SomeException -> Maybe Stack.CallStack) ->
-  e ->
-  Exception
-fromException getCallStack e =
+fromSomeException :: Catch.SomeException -> Exception
+fromSomeException (Catch.SomeException e) =
   empty
-    { stacktrace = fmap Stacktrace.fromCallStack . getCallStack $ Catch.toException e,
-      type_ = Text.pack . show $ Typeable.typeOf e,
+    { type_ = Text.pack . show $ Typeable.typeOf e,
       value = Text.pack $ Catch.displayException e
     }

--- a/source/library/Patrol/Type/Exceptions.hs
+++ b/source/library/Patrol/Type/Exceptions.hs
@@ -2,7 +2,6 @@ module Patrol.Type.Exceptions where
 
 import qualified Control.Monad.Catch as Catch
 import qualified Data.Aeson as Aeson
-import qualified GHC.Stack as Stack
 import qualified Patrol.Extra.Aeson as Aeson
 import qualified Patrol.Type.Exception as Exception
 
@@ -24,12 +23,8 @@ empty =
     { values = []
     }
 
-fromException ::
-  (Catch.Exception e) =>
-  (Catch.SomeException -> Maybe Stack.CallStack) ->
-  e ->
+fromSomeException :: Catch.SomeException -> Exceptions
+fromSomeException e =
   Exceptions
-fromException getCallStack e =
-  Exceptions
-    { values = [Exception.fromException getCallStack e]
+    { values = [Exception.fromSomeException e]
     }

--- a/source/test-suite/Patrol/Type/DsnSpec.hs
+++ b/source/test-suite/Patrol/Type/DsnSpec.hs
@@ -78,6 +78,12 @@ spec = Hspec.describe "Patrol.Type.Dsn" $ do
     Hspec.it "fails with a fragment" $ do
       Dsn.fromUri [Uri.uri|a://b@c/d#|] `Hspec.shouldBe` Nothing
 
+    Hspec.it "fails without a project ID" $ do
+      Dsn.fromUri [Uri.uri|a://b@c|] `Hspec.shouldBe` Nothing
+
+    Hspec.it "fails with a trailing slash" $ do
+      Dsn.fromUri [Uri.uri|a://b@c/d/|] `Hspec.shouldBe` Nothing
+
   Hspec.describe "intoUri" $ do
     Hspec.it "converts a minimal DSN into URI" $ do
       let dsn =

--- a/source/test-suite/Patrol/Type/EnvelopeSpec.hs
+++ b/source/test-suite/Patrol/Type/EnvelopeSpec.hs
@@ -2,6 +2,7 @@
 
 module Patrol.Type.EnvelopeSpec where
 
+import qualified Control.Monad.Catch as Catch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Builder as Builder
@@ -69,7 +70,7 @@ spec = Hspec.describe "Patrol.Type.Envelope" $ do
   Hspec.describe "fromEvent" $ do
     Hspec.it "sets the header" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       let envelope = Envelope.fromEvent dsn event {Event.timestamp = Nothing}
       let expected =
             Headers.fromObject $
@@ -86,44 +87,44 @@ spec = Hspec.describe "Patrol.Type.Envelope" $ do
 
     Hspec.it "sets the items" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       let envelope = Envelope.fromEvent dsn event
       Envelope.items envelope `Hspec.shouldNotSatisfy` null
 
   Hspec.describe "intoRequest" $ do
     Hspec.it "sets the method" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       Client.method request `Hspec.shouldBe` Http.methodPost
 
     Hspec.it "sets the host" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       Client.host request `Hspec.shouldBe` "sentry.test"
 
     Hspec.it "sets the port" $ do
       dsn <- Dsn.fromText "http://key@sentry.test:8080/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       Client.port request `Hspec.shouldBe` 8080
 
     Hspec.it "sets the path" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       Client.path request `Hspec.shouldBe` "/api/1/envelope/"
 
     Hspec.it "handles a custom path" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/custom/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       Client.path request `Hspec.shouldBe` "/custom/api/1/envelope/"
 
     Hspec.it "sets the body" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       actual <- case Client.requestBody request of
         Client.RequestBodyBS byteString -> pure byteString
@@ -133,18 +134,18 @@ spec = Hspec.describe "Patrol.Type.Envelope" $ do
 
     Hspec.it "sets the content type" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       lookup Http.hContentType (Client.requestHeaders request) `Hspec.shouldBe` Just Constant.applicationXSentryEnvelope
 
     Hspec.it "sets the user agent" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       lookup Http.hUserAgent (Client.requestHeaders request) `Hspec.shouldBe` Just (Text.encodeUtf8 Constant.userAgent)
 
     Hspec.it "sets the authorization" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      envelope <- Envelope.fromException (const Nothing) dsn $ userError ""
+      let envelope = Envelope.fromEvent dsn Event.empty
       request <- Envelope.intoRequest dsn envelope
       lookup Constant.xSentryAuth (Client.requestHeaders request) `Hspec.shouldBe` Just (Dsn.intoAuthorization dsn)

--- a/source/test-suite/Patrol/Type/EnvelopeSpec.hs
+++ b/source/test-suite/Patrol/Type/EnvelopeSpec.hs
@@ -2,7 +2,6 @@
 
 module Patrol.Type.EnvelopeSpec where
 
-import qualified Control.Monad.Catch as Catch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.ByteString.Builder as Builder
@@ -70,8 +69,7 @@ spec = Hspec.describe "Patrol.Type.Envelope" $ do
   Hspec.describe "fromEvent" $ do
     Hspec.it "sets the header" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      event <- Event.fromSomeException . Catch.toException $ userError ""
-      let envelope = Envelope.fromEvent dsn event {Event.timestamp = Nothing}
+      let envelope = Envelope.fromEvent dsn Event.empty
       let expected =
             Headers.fromObject $
               KeyMap.fromList
@@ -87,8 +85,7 @@ spec = Hspec.describe "Patrol.Type.Envelope" $ do
 
     Hspec.it "sets the items" $ do
       dsn <- Dsn.fromText "http://key@sentry.test/1"
-      event <- Event.fromSomeException . Catch.toException $ userError ""
-      let envelope = Envelope.fromEvent dsn event
+      let envelope = Envelope.fromEvent dsn Event.empty
       Envelope.items envelope `Hspec.shouldNotSatisfy` null
 
   Hspec.describe "intoRequest" $ do

--- a/source/test-suite/Patrol/Type/EventSpec.hs
+++ b/source/test-suite/Patrol/Type/EventSpec.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+-- In the use of ‘intoRequest’ (imported from Patrol.Type.Event)
+{-# OPTIONS_GHC -Wno-deprecations #-}
 
 module Patrol.Type.EventSpec where
 
+import qualified Control.Exception as Catch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.QQ.Simple as Aeson
 import qualified Data.ByteString.Lazy as LazyByteString
@@ -273,35 +276,35 @@ spec = Hspec.describe "Patrol.Type.Event" $ do
       request <- Event.intoRequest dsn event
       lookup Constant.xSentryAuth (Client.requestHeaders request) `Hspec.shouldSatisfy` Maybe.isJust
 
-  Hspec.describe "fromException" $ do
+  Hspec.describe "fromSomeException" $ do
     Hspec.it "sets the environment" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.environment event `Hspec.shouldBe` Text.pack "production"
 
     Hspec.it "sets the event ID" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.eventId event `Hspec.shouldNotBe` EventId.empty
 
     Hspec.it "sets the exception" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.exception event `Hspec.shouldSatisfy` Maybe.isJust
 
     Hspec.it "sets the level" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.level event `Hspec.shouldBe` Just Level.Error
 
     Hspec.it "sets the platform" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.platform event `Hspec.shouldBe` Just Platform.Haskell
 
     Hspec.it "sets the timestamp" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.timestamp event `Hspec.shouldSatisfy` Maybe.isJust
 
     Hspec.it "sets the type" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.type_ event `Hspec.shouldBe` Just EventType.Default
 
     Hspec.it "sets the version" $ do
-      event <- Event.fromException (const Nothing) $ userError ""
+      event <- Event.fromSomeException . Catch.toException $ userError ""
       Event.version event `Hspec.shouldBe` Constant.sentryVersion

--- a/source/test-suite/Patrol/Type/ExceptionSpec.hs
+++ b/source/test-suite/Patrol/Type/ExceptionSpec.hs
@@ -2,11 +2,11 @@
 
 module Patrol.Type.ExceptionSpec where
 
+import qualified Control.Monad.Catch as Catch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.QQ.Simple as Aeson
 import qualified Data.Map as Map
 import qualified Data.Text as Text
-import qualified GHC.Stack as Stack
 import qualified Patrol.Type.Exception as Exception
 import qualified Patrol.Type.Mechanism as Mechanism
 import qualified Patrol.Type.Stacktrace as Stacktrace
@@ -52,16 +52,11 @@ spec = Hspec.describe "Patrol.Type.Exception" $ do
           json = [Aeson.aesonQQ| { "value": "example-value" } |]
       Aeson.toJSON exception `Hspec.shouldBe` json
 
-  Hspec.describe "fromException" $ do
-    Hspec.it "sets the stacktrace" $ do
-      let callStack = Stack.callStack
-      let exception = Exception.fromException (const $ Just callStack) $ userError ""
-      Exception.stacktrace exception `Hspec.shouldBe` Just (Stacktrace.fromCallStack callStack)
-
+  Hspec.describe "fromSomeException" $ do
     Hspec.it "sets the type" $ do
-      let exception = Exception.fromException (const Nothing) $ userError ""
+      let exception = Exception.fromSomeException . Catch.toException $ userError ""
       Exception.type_ exception `Hspec.shouldBe` Text.pack "IOException"
 
     Hspec.it "sets the value" $ do
-      let exception = Exception.fromException (const Nothing) $ userError "example-exception-value"
+      let exception = Exception.fromSomeException . Catch.toException $ userError "example-exception-value"
       Exception.value exception `Hspec.shouldBe` Text.pack "user error (example-exception-value)"

--- a/source/test-suite/Patrol/Type/ExceptionsSpec.hs
+++ b/source/test-suite/Patrol/Type/ExceptionsSpec.hs
@@ -2,6 +2,7 @@
 
 module Patrol.Type.ExceptionsSpec where
 
+import qualified Control.Monad.Catch as Catch
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.QQ.Simple as Aeson
 import qualified Data.Text as Text
@@ -23,7 +24,7 @@ spec = Hspec.describe "Patrol.Type.Exceptions" $ do
           json = [Aeson.aesonQQ| { "values": [ { "type": "example-type" } ] } |]
       Aeson.toJSON exceptions `Hspec.shouldBe` json
 
-  Hspec.describe "fromException" $ do
+  Hspec.describe "fromSomeException" $ do
     Hspec.it "works" $ do
-      let exceptions = Exceptions.fromException (const Nothing) $ userError ""
+      let exceptions = Exceptions.fromSomeException . Catch.toException $ userError ""
       Exceptions.values exceptions `Hspec.shouldNotSatisfy` null


### PR DESCRIPTION
This follows up from #32. These changes will have to be released as a breaking change. Furthermore, version 1.0.1.0 should be deprecated since it included breaking changes. 