### PR TITLE
extend 'Patrol.Type.BreadcrumbType'

### DIFF
--- a/source/library/Patrol/Type/BreadcrumbType.hs
+++ b/source/library/Patrol/Type/BreadcrumbType.hs
@@ -2,14 +2,42 @@ module Patrol.Type.BreadcrumbType where
 
 import qualified Data.Aeson as Aeson
 
+-- | <https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/#breadcrumb-types>
 data BreadcrumbType
-  = Default
-  | Http
-  | Navigation
+  = -- | A generic breadcrumb, typically a log message or something user-generated.
+    Default
+  | -- | A generic debug event, typically a log message.
+    Debug
+  | -- | An error that occurred before the exception that generates an
+    -- 'Patrol.Type.Event.Event'.
+    Error
+  | -- | A URL change in a web application, a UI transition on mobile or desktop,
+    -- or some other event with similar semantics.
+    Navigation
+  | -- | An HTTP request transmitted from your application.
+    Http
+  | -- | Information that helps identify the root cause of the issue or for whom
+    -- the error occurred.
+    Info
+  | -- | A query made to the application.
+    Query
+  | -- | A tracing event.
+    Transaction
+  | -- | A user interaction with the application's UI, synonymouos with 'User'.
+    UI
+  | -- | A user interaction with the application's UI, synonymous with 'UI'.
+    User
   deriving (Eq, Show)
 
 instance Aeson.ToJSON BreadcrumbType where
   toJSON breadcrumbType = Aeson.toJSON $ case breadcrumbType of
     Default -> "default"
-    Http -> "http"
+    Debug -> "debug"
+    Error -> "error"
     Navigation -> "navigation"
+    Http -> "http"
+    Info -> "info"
+    Query -> "query"
+    Transaction -> "transaction"
+    UI -> "ui"
+    User -> "user"

--- a/source/test-suite/Patrol/Type/BreadcrumbTypeSpec.hs
+++ b/source/test-suite/Patrol/Type/BreadcrumbTypeSpec.hs
@@ -13,8 +13,29 @@ spec = Hspec.describe "Patrol.Type.BreadcrumbType" $ do
     Hspec.it "works for Default" $ do
       Aeson.toJSON BreadcrumbType.Default `Hspec.shouldBe` [Aeson.aesonQQ| "default" |]
 
-    Hspec.it "works for Http" $ do
-      Aeson.toJSON BreadcrumbType.Http `Hspec.shouldBe` [Aeson.aesonQQ| "http" |]
+    Hspec.it "works for Debug" $ do
+      Aeson.toJSON BreadcrumbType.Debug `Hspec.shouldBe` [Aeson.aesonQQ| "debug" |]
+
+    Hspec.it "works for Error" $ do
+      Aeson.toJSON BreadcrumbType.Error `Hspec.shouldBe` [Aeson.aesonQQ| "error" |]
 
     Hspec.it "works for Navigation" $ do
       Aeson.toJSON BreadcrumbType.Navigation `Hspec.shouldBe` [Aeson.aesonQQ| "navigation" |]
+
+    Hspec.it "works for Http" $ do
+      Aeson.toJSON BreadcrumbType.Http `Hspec.shouldBe` [Aeson.aesonQQ| "http" |]
+
+    Hspec.it "works for Info" $ do
+      Aeson.toJSON BreadcrumbType.Info `Hspec.shouldBe` [Aeson.aesonQQ| "info" |]
+
+    Hspec.it "works for Query" $ do
+      Aeson.toJSON BreadcrumbType.Query `Hspec.shouldBe` [Aeson.aesonQQ| "query" |]
+
+    Hspec.it "works for Transaction" $ do
+      Aeson.toJSON BreadcrumbType.Transaction `Hspec.shouldBe` [Aeson.aesonQQ| "transaction" |]
+
+    Hspec.it "works for UI" $ do
+      Aeson.toJSON BreadcrumbType.UI `Hspec.shouldBe` [Aeson.aesonQQ| "ui" |]
+
+    Hspec.it "works for User" $ do
+      Aeson.toJSON BreadcrumbType.User `Hspec.shouldBe` [Aeson.aesonQQ| "user" |]


### PR DESCRIPTION
## description
adds the remaining types enumerated in https://develop.sentry.dev/sdk/data-model/event-payloads/breadcrumbs/#breadcrumb-types