### PR TITLE
Optimize item serialization

### DIFF
--- a/source/library/Patrol/Type/Item.hs
+++ b/source/library/Patrol/Type/Item.hs
@@ -4,9 +4,9 @@ module Patrol.Type.Item where
 
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Key
-import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Lazy as LazyByteString
+import Data.Int (Int64)
 import qualified Patrol.Type.ClientReport as ClientReport
 import qualified Patrol.Type.Event as Event
 
@@ -27,17 +27,20 @@ data Item
 
 serialize :: Item -> Builder.Builder
 serialize item = case item of
-  Event event ->
-    let payload = LazyByteString.toStrict $ Aeson.encode event
-        headers = buildHeaders "event" (ByteString.length payload)
-     in headers <> Builder.char7 '\n' <> Builder.byteString payload
-  ClientReport clientReport ->
-    let payload = LazyByteString.toStrict $ Aeson.encode clientReport
-        headers = buildHeaders "client_report" (ByteString.length payload)
-     in headers <> Builder.char7 '\n' <> Builder.byteString payload
+  Event event -> envelopeItem "event" (Aeson.encode event)
+  ClientReport clientReport -> envelopeItem "client_report" (Aeson.encode clientReport)
   Raw -> mempty
   where
-    buildHeaders :: Key.Key -> Int -> Builder.Builder
+    -- Keep the encoded payload lazy: take the item-header length from the lazy
+    -- chunks and stream them straight into the builder, rather than forcing a
+    -- contiguous strict copy of every payload.
+    envelopeItem :: Key.Key -> LazyByteString.ByteString -> Builder.Builder
+    envelopeItem type_ payload =
+      buildHeaders type_ (LazyByteString.length payload)
+        <> Builder.char7 '\n'
+        <> Builder.lazyByteString payload
+
+    buildHeaders :: Key.Key -> Int64 -> Builder.Builder
     buildHeaders type_ length_ =
       Aeson.fromEncoding $
         Aeson.pairs ("type" Aeson..= type_ <> "length" Aeson..= length_)


### PR DESCRIPTION
## notes

depends on #62

## description

this is a _very_ small optimization, but the `toStrict` call on each `Item.serialize` is only cheap if everything fits in a single chunk; for larger `Envelope`s you end up doing a bit of unnecessary copying for something that's (probably) just going to flush to a LBS when it goes out in the client call.